### PR TITLE
Fix: Support custom models for schedule monitor

### DIFF
--- a/src/Filament/Resources/MonitoredScheduledTaskLogItemResource.php
+++ b/src/Filament/Resources/MonitoredScheduledTaskLogItemResource.php
@@ -15,9 +15,12 @@ use Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem;
 
 class MonitoredScheduledTaskLogItemResource extends Resource
 {
-    protected static ?string $model = MonitoredScheduledTaskLogItem::class;
-
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function getModel(): string
+    {
+        return config('schedule-monitor.models.monitored_scheduled_log_item');
+    }
 
     public static function getNavigationGroup(): ?string
     {
@@ -107,7 +110,7 @@ class MonitoredScheduledTaskLogItemResource extends Resource
                     ->label(__('filament-schedule-monitor::translations.name'))
                     ->multiple()
                     ->options(
-                        MonitoredScheduledTask::all()->pluck('name', 'id')
+                        MonitoredScheduledTaskResource::getModel()::all()->pluck('name', 'id')
                     ),
             ])
             ->filtersLayout(Tables\Enums\FiltersLayout::AboveContent);

--- a/src/Filament/Resources/MonitoredScheduledTaskResource.php
+++ b/src/Filament/Resources/MonitoredScheduledTaskResource.php
@@ -11,7 +11,10 @@ use Spatie\ScheduleMonitor\Models\MonitoredScheduledTask;
 
 class MonitoredScheduledTaskResource extends Resource
 {
-    protected static ?string $model = MonitoredScheduledTask::class;
+    public static function getModel(): string
+    {
+        return config('schedule-monitor.models.monitored_scheduled_task');
+    }
 
     public static function getNavigationGroup(): ?string
     {


### PR DESCRIPTION
### Description
This Pull Request addresses the issue where the package is tightly coupled with `Spatie\ScheduleMonitor\Models\MonitoredScheduledTask` and `Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem`. While the `spatie/laravel-schedule-monitor` package allows users to specify custom models for these tables via configuration, the package currently fails to respect those configurations and continues to use the default models.

### Problem
When custom models are specified in the `config/schedule-monitor.php` file, the package does not switch to using the configured models. This leads to errors when different table names are used.

### Solution
This fix modifies the package to use the custom models specified in the configuration file for `MonitoredScheduledTask` and `MonitoredScheduledTaskLogItem`.
All references to the default models have been replaced with dynamic lookups, ensuring that custom models will be used if defined in the config.
Impact
This change ensures that users with custom models or table structures for scheduled tasks can still use the package without issues.
