### PR TITLE
Add navigation cluster configuration for resources

### DIFF
--- a/config/filament-schedule-monitor.php
+++ b/config/filament-schedule-monitor.php
@@ -9,6 +9,7 @@ return [
             'navigation_label' => 'filament-schedule-monitor::translations.monitored_scheduled_task.navigation_label',
             'navigation_icon' => 'heroicon-o-cpu-chip',
             'navigation_sort' => null,
+            'navigation_cluster' => null,
         ],
         'monitored_scheduled_task_log_item' => [
             'label' => 'filament-schedule-monitor::translations.monitored_scheduled_task_log_item.label',
@@ -17,6 +18,7 @@ return [
             'navigation_label' => 'filament-schedule-monitor::translations.monitored_scheduled_task_log_item.navigation_label',
             'navigation_icon' => 'heroicon-o-cpu-chip',
             'navigation_sort' => null,
+            'navigation_cluster' => null,
         ]
     ]
 ];

--- a/src/Filament/Resources/MonitoredScheduledTaskLogItemResource.php
+++ b/src/Filament/Resources/MonitoredScheduledTaskLogItemResource.php
@@ -49,6 +49,11 @@ class MonitoredScheduledTaskLogItemResource extends Resource
         return config('filament-schedule-monitor.resources.monitored_scheduled_task_log_item.navigation_sort');
     }
 
+    public static function getCluster(): ?string
+    {
+        return config('filament-schedule-monitor.resources.monitored_scheduled_task_log_item.navigation_cluster', null);
+    }
+
     public static function table(Table $table): Table
     {
         return $table

--- a/src/Filament/Resources/MonitoredScheduledTaskResource.php
+++ b/src/Filament/Resources/MonitoredScheduledTaskResource.php
@@ -43,6 +43,11 @@ class MonitoredScheduledTaskResource extends Resource
         return config('filament-schedule-monitor.resources.monitored_scheduled_task.navigation_sort');
     }
 
+    public static function getCluster(): ?string
+    {
+        return config('filament-schedule-monitor.resources.monitored_scheduled_task.navigation_cluster', null);
+    }
+
     public static function table(Table $table): Table
     {
         return $table


### PR DESCRIPTION
Introduced a `navigation_cluster` option in the config and corresponding `getCluster` method in resource classes. This enables grouping navigation items for better organization and flexibility in the interface.